### PR TITLE
feat: Limit the possible number of entries in a channel

### DIFF
--- a/web_services/profile/app.js
+++ b/web_services/profile/app.js
@@ -44,7 +44,7 @@ app.post("/upload/:channel", function (req, res) {
 
     // Bail out if channel is full
     if (current_data.length >= config.channel_entry_limit) {
-      res.status(config.channel_limit_error_code).json({error: `Channel full`});
+      res.status(config.channel_limit_response_code).json({error: config.channel_limit_message});
       return;
     }
 

--- a/web_services/profile/app.js
+++ b/web_services/profile/app.js
@@ -41,6 +41,13 @@ app.post("/upload/:channel", function (req, res) {
   const current_data = dataCache.get(channel)
   if (current_data) {
     // provided data is a responder profile. Add to existing channel.
+
+    // Bail out if channel is full
+    if (current_data.length >= config.channel_entry_limit) {
+      res.status(config.channel_limit_error_code).json({error: `Channel full`});
+      return;
+    }
+
     // Check if there is already a profile with the provided uuid to prevent duplicates
     const existingProfile = current_data.find(entry => (entry.uuid === uuid))
     if (existingProfile) {

--- a/web_services/profile/config.js
+++ b/web_services/profile/config.js
@@ -11,9 +11,14 @@ const notification_service = is_dev
   ? process.env.NOTIFICATION_SERVICE_DEV
   : process.env.NOTIFICATION_SERVICE_RELEASE;
 
+const channel_entry_limit = 30;
+const channel_limit_error_code = 550;
+
 module.exports = {
   is_dev,
   port,
   node_cache,
   notification_service,
+  channel_entry_limit,
+  channel_limit_error_code,
 };

--- a/web_services/profile/config.js
+++ b/web_services/profile/config.js
@@ -12,7 +12,8 @@ const notification_service = is_dev
   : process.env.NOTIFICATION_SERVICE_RELEASE;
 
 const channel_entry_limit = 30;
-const channel_limit_error_code = 550;
+const channel_limit_response_code = 400;
+const channel_limit_message = "Channel full"
 
 module.exports = {
   is_dev,
@@ -20,5 +21,6 @@ module.exports = {
   node_cache,
   notification_service,
   channel_entry_limit,
-  channel_limit_error_code,
+  channel_limit_response_code,
+  channel_limit_message
 };

--- a/web_services/profile/test/channel_limit.test.js
+++ b/web_services/profile/test/channel_limit.test.js
@@ -35,6 +35,7 @@ describe('Channel limit', () => {
             data: `Another profile data`,
             uuid: uuidv4(),
         })
-        .expect(config.channel_limit_error_code)
+        .expect(config.channel_limit_response_code)
+        expect(res.body).toHaveProperty('error', config.channel_limit_message)
     })
 })

--- a/web_services/profile/test/channel_limit.test.js
+++ b/web_services/profile/test/channel_limit.test.js
@@ -1,0 +1,40 @@
+const { v4: uuidv4 } = require('uuid');
+const request = require('supertest')
+const app = require('../app')
+const config = require('../config')
+
+const channelId = uuidv4();
+
+describe('Channel limit', () => {
+
+    let channelEntries = [];
+
+    it(`should allow max number of entries`, async () => {
+        // completely fill channel with random entries
+        for (i = 0; i < config.channel_entry_limit; i++) {
+            channelEntries.push({
+                data: `Profile ${i} data`,
+                uuid: uuidv4(),
+            })
+            const res = await request(app)
+            .post(`/upload/${channelId}`)
+            .send(channelEntries[i])
+            .expect(201)
+        }
+        // double-check channel list returns correct size
+        const res = await request(app)
+        .get(`/list/${channelId}`)
+        .expect(200)
+        expect(res.body.profileIds).toHaveLength(config.channel_entry_limit);
+    })
+
+    it(`should fail when uploading additional entries`, async() => {
+        const res = await request(app)
+        .post(`/upload/${channelId}`)
+        .send({
+            data: `Another profile data`,
+            uuid: uuidv4(),
+        })
+        .expect(config.channel_limit_error_code)
+    })
+})


### PR DESCRIPTION
Implement a limit on the number of entries a channel can hold.
Respond with http error code 400 for this condition (can be configured in config.js).