### PR TITLE
Reduce image size

### DIFF
--- a/consensus/Dockerfile
+++ b/consensus/Dockerfile
@@ -1,7 +1,5 @@
 # 1st stage
-FROM python:3.7-slim as builder
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends build-essential gcc
+FROM python:3.7 as builder
 
 ADD . /code
 WORKDIR /code/

--- a/consensus/Dockerfile
+++ b/consensus/Dockerfile
@@ -1,15 +1,24 @@
-FROM ubuntu:18.04
-
-COPY docker-entrypoint.sh /usr/local/bin/
+# 1st stage
+FROM python:3.7-slim as builder
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends build-essential gcc
 
 ADD . /code
 WORKDIR /code/
+# Install with --user prefix so all installed packages are easy to copy in next stage
+RUN pip3 install --user -r requirements.txt
 
+# 2nd stage
+FROM python:3.7-slim as runner
+ADD . /code
+WORKDIR /code/
 ADD https://download.arangodb.com/arangodb37/Community/Linux/arangodb3-client_3.7.5-1_amd64.deb ./
 RUN dpkg -i arangodb3-client_3.7.5-1_amd64.deb
-
-RUN apt update && apt -y install python3 python3-pip
-RUN pip3 install -r requirements.txt
+COPY docker-entrypoint.sh /usr/local/bin/
+# Copy installed packages from 1st stage
+COPY --from=builder /root/.local /root/.local
+# Make sure scripts in .local are usable:
+ENV PATH=/root/.local/bin:$PATH
 
 # Always execute entrypoint script
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/consensus/Dockerfile
+++ b/consensus/Dockerfile
@@ -13,7 +13,7 @@ FROM python:3.7-slim as runner
 ADD . /code
 WORKDIR /code/
 ADD https://download.arangodb.com/arangodb37/Community/Linux/arangodb3-client_3.7.5-1_amd64.deb ./
-RUN dpkg -i arangodb3-client_3.7.5-1_amd64.deb
+RUN dpkg -i arangodb3-client_3.7.5-1_amd64.deb && rm arangodb3-client_3.7.5-1_amd64.deb
 COPY docker-entrypoint.sh /usr/local/bin/
 # Copy installed packages from 1st stage
 COPY --from=builder /root/.local /root/.local

--- a/consensus/receiver.py
+++ b/consensus/receiver.py
@@ -62,7 +62,7 @@ def save_snapshot(block):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     collections_file = os.path.join(dir_path, 'collections.json')
     os.system(
-        f'arangodump --overwrite true --compress-output false --server.password "" --output-directory {dir_name} --maskings {collections_file}')
+        f'arangodump --overwrite true --compress-output false --server.password "" --server.endpoint "tcp://{config.BN_ARANGO_HOST}:{config.BN_ARANGO_PORT}" --output-directory {dir_name} --maskings {collections_file}')
     shutil.move(dir_name, fnl_dir_name)
 
 

--- a/scorer/Dockerfile
+++ b/scorer/Dockerfile
@@ -1,13 +1,25 @@
-FROM ubuntu:20.04
+#1st stage
+FROM python:3.7-slim as builder
 
 ADD . /code
 WORKDIR /code/
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends build-essential gcc
+ADD https://github.com/BrightID/BrightID-AntiSybil/archive/v1.2.0.tar.gz ./
+RUN tar -xzf v1.2.0.tar.gz && rm v1.2.0.tar.gz
+# Install with --user prefix so all installed packages are easy to copy in next stage
+RUN pip3 install --user BrightID-AntiSybil-1.2.0/.
+RUN pip3 install --user -r requirements.txt
 
+# 2nd stage
+FROM python:3.7-slim as runner
+ADD . /code
+WORKDIR /code/
 ADD https://download.arangodb.com/arangodb37/Community/Linux/arangodb3-client_3.7.5-1_amd64.deb ./
 RUN dpkg -i arangodb3-client_3.7.5-1_amd64.deb
-RUN apt update && apt -y install python3 python3-pip
-ADD https://github.com/BrightID/BrightID-AntiSybil/archive/v1.2.1.tar.gz ./
-RUN tar -xzf v1.2.1.tar.gz && rm v1.2.1.tar.gz
-RUN pip3 install BrightID-AntiSybil-1.2.1/.
-RUN pip3 install -r requirements.txt
+# Copy installed packages from 1st stage
+COPY --from=builder /root/.local /root/.local
+# Make sure scripts in .local are usable:
+ENV PATH=/root/.local/bin:$PATH
+
 CMD python3 -u runner.py

--- a/scorer/Dockerfile
+++ b/scorer/Dockerfile
@@ -1,10 +1,8 @@
 #1st stage
-FROM python:3.7-slim as builder
+FROM python:3.7 as builder
 
 ADD . /code
 WORKDIR /code/
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends build-essential gcc
 ADD https://github.com/BrightID/BrightID-AntiSybil/archive/v1.2.1.tar.gz ./
 RUN tar -xzf v1.2.1.tar.gz && rm v1.2.1.tar.gz
 # Install with --user prefix so all installed packages are easy to copy in next stage

--- a/scorer/Dockerfile
+++ b/scorer/Dockerfile
@@ -16,7 +16,7 @@ FROM python:3.7-slim as runner
 ADD . /code
 WORKDIR /code/
 ADD https://download.arangodb.com/arangodb37/Community/Linux/arangodb3-client_3.7.5-1_amd64.deb ./
-RUN dpkg -i arangodb3-client_3.7.5-1_amd64.deb
+RUN dpkg -i arangodb3-client_3.7.5-1_amd64.deb && rm arangodb3-client_3.7.5-1_amd64.deb
 # Copy installed packages from 1st stage
 COPY --from=builder /root/.local /root/.local
 # Make sure scripts in .local are usable:

--- a/scorer/Dockerfile
+++ b/scorer/Dockerfile
@@ -5,10 +5,10 @@ ADD . /code
 WORKDIR /code/
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc
-ADD https://github.com/BrightID/BrightID-AntiSybil/archive/v1.2.0.tar.gz ./
-RUN tar -xzf v1.2.0.tar.gz && rm v1.2.0.tar.gz
+ADD https://github.com/BrightID/BrightID-AntiSybil/archive/v1.2.1.tar.gz ./
+RUN tar -xzf v1.2.1.tar.gz && rm v1.2.1.tar.gz
 # Install with --user prefix so all installed packages are easy to copy in next stage
-RUN pip3 install --user BrightID-AntiSybil-1.2.0/.
+RUN pip3 install --user BrightID-AntiSybil-1.2.1/.
 RUN pip3 install --user -r requirements.txt
 
 # 2nd stage

--- a/scorer/runner.py
+++ b/scorer/runner.py
@@ -101,7 +101,7 @@ def process(snapshot):
     print(f'{get_time()} - processing {snapshot} started ...')
     # restore snapshot
     fname = os.path.join(config.SNAPSHOTS_PATH, snapshot)
-    os.system(f"arangorestore --server.username 'root' --server.password '' --server.database snapshot --create-database true --create-collection true --import-data true --input-directory {fname}")
+    os.system(f"arangorestore --server.username 'root' --server.password '' --server.endpoint 'tcp://{config.BN_ARANGO_HOST}:{config.BN_ARANGO_PORT}' --server.database snapshot --create-database true --create-collection true --import-data true --input-directory {fname}")
 
     block = get_block(snapshot)
     for v in verifiers:

--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,10 +1,23 @@
-FROM ubuntu:18.04
+# 1st stage
+FROM python:3.7 as builder
 
 ADD . /code
 WORKDIR /code/
 
-RUN apt update && apt -y install python3 python3-pip cron
-RUN pip3 install -r requirements.txt
+# Install with --user prefix so all installed packages are easy to copy in next stage
+RUN pip3 install --user -r requirements.txt
+
+# 2nd stage
+FROM python:3.7-slim as runner
+ADD . /code
+WORKDIR /code/
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install cron
+
+# Copy installed packages from 1st stage
+COPY --from=builder /root/.local /root/.local
+# Make sure scripts in .local are usable:
+ENV PATH=/root/.local/bin:$PATH
 
 ADD update-cron /etc/cron.d/update-cron
 RUN chmod 0644 /etc/cron.d/update-cron

--- a/updater/entrypoint.sh
+++ b/updater/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # make BN_UPDATER_* and BN_ARANGO_* env vars available to cronjob
-printenv | grep "BN_UPDATER\|BN_ARANGO" > /tmp/environment_vars
-python3 -u /code/start.py
-
+printenv | grep "BN_UPDATER\|BN_ARANGO\|PATH" > /tmp/environment_vars
+python -u /code/start.py

--- a/updater/update-cron
+++ b/updater/update-cron
@@ -1,3 +1,3 @@
-* * * * * root bash -c "set -o allexport; source /tmp/environment_vars; set +o allexport; cd /code; python3 -u sponsorships.py >> /var/log/cron.log 2>&1"
-3-59/5 * * * * root bash -c "set -o allexport; source /tmp/environment_vars; set +o allexport; cd /code; python3 -u apps.py >> /var/log/cron.log 2>&1"
-5-59/5 * * * * root bash -c "set -o allexport; source /tmp/environment_vars; set +o allexport; cd /code; python3 -u seed_groups.py >> /var/log/cron.log 2>&1"
+* * * * * root bash -c "set -o allexport; source /tmp/environment_vars; set +o allexport; cd /code; python -u sponsorships.py >> /var/log/cron.log 2>&1"
+3-59/5 * * * * root bash -c "set -o allexport; source /tmp/environment_vars; set +o allexport; cd /code; python -u apps.py >> /var/log/cron.log 2>&1"
+5-59/5 * * * * root bash -c "set -o allexport; source /tmp/environment_vars; set +o allexport; cd /code; python -u seed_groups.py >> /var/log/cron.log 2>&1"

--- a/web_services/Dockerfile
+++ b/web_services/Dockerfile
@@ -1,14 +1,14 @@
-FROM node:8
+FROM mhart/alpine-node:8
+
 ADD . /code
 WORKDIR /code/profile/
-RUN npm install
-RUN npm install foxx-cli@1.3.0 -g
 
-RUN apt-get update && apt-get install -y netcat
+RUN npm install &&\
+ npm install foxx-cli@1.3.0 -g &&\
+ npm cache clean --force &&\
+ apk add --update --no-cache netcat-openbsd curl
 
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY wait-for.sh /wait-for.sh
 
-CMD /entrypoint.sh && nodejs server.js
-
-
+CMD /entrypoint.sh && node server.js

--- a/web_services/docker-entrypoint.sh
+++ b/web_services/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -eo pipefail
 /wait-for.sh $BN_ARANGO_HOST:$BN_ARANGO_PORT
 


### PR DESCRIPTION
Reduce size of docker images by using smaller base images and leverage multistage builds. 
Overall these changes bring down image size of the DAppNode package from ~790MB to ~280MB.
