### PR TITLE
add 'delete' method to remove entries from profile service channel

### DIFF
--- a/web_services/profile/app.js
+++ b/web_services/profile/app.js
@@ -135,6 +135,47 @@ app.get("/download/:channel/:uuid", function (req, res, next) {
   });
 });
 
+app.delete("/:channel/:uuid", function (req, res, next) {
+  const { channel, uuid } = req.params;
+
+  if (!uuid) {
+    res.status(400).json({ error: "missing uuid" });
+    return;
+  }
+
+  if (!channel) {
+    res.status(400).json({ error: "missing channel" });
+    return;
+  }
+
+  // get array of profiles stored in channel
+  const current_data = dataCache.get(channel);
+  if (!current_data) {
+    res.status(404).json({error: `Channel ${channel} not found`});
+    return;
+  }
+
+  // remove entry
+  const new_data = current_data.filter((entry) => (entry.uuid !== uuid))
+  if (new_data.length === current_data.length) {
+    // entry to be deleted not found :-(
+    res.status(404).json({error: `Profile ${uuid} in channel ${channel} not found`});
+    return;
+  }
+
+  // save data in cache
+  dataCache.set(channel, new_data, async function (err, success) {
+    if (err) {
+      console.log(err);
+      res.status(500).json({ error: "unable to store profile data" });
+      return;
+    }
+    res.status(200);
+    res.json({ success: true });
+  });
+});
+
+
 app.get("/download/:uuid", function (req, res, next) {
   const { uuid } = req.params;
 

--- a/web_services/profile/test/channel_limit.test.js
+++ b/web_services/profile/test/channel_limit.test.js
@@ -5,7 +5,7 @@ const config = require('../config')
 
 const channelId = uuidv4();
 
-describe('Channel limit', () => {
+describe('Standard channel limit', () => {
 
     let channelEntries = [];
 
@@ -40,7 +40,7 @@ describe('Channel limit', () => {
     })
 
     it(`should not fail when uploading additional entries starting with "sig_", "connection_" and "group_" to recovery channels`, async() => {
-        let res = await request(app)
+        await request(app)
         .post(`/upload/${channelId}`)
         .send({
             data: `Another profile data`,
@@ -48,7 +48,7 @@ describe('Channel limit', () => {
         })
         .expect(201)
         // double-check channel list returns correct size
-        res = await request(app)
+        const res = await request(app)
         .get(`/list/${channelId}`)
         .expect(200)
         expect(res.body.profileIds).toHaveLength(config.channel_entry_limit + 1);

--- a/web_services/profile/test/remove_content.test.js
+++ b/web_services/profile/test/remove_content.test.js
@@ -1,0 +1,171 @@
+const { v4: uuidv4 } = require('uuid');
+const request = require('supertest')
+const app = require('../app')
+const config = require('../config')
+
+
+const setupChannel = async (numEntries) => {
+    channelId = uuidv4();
+    channelEntries = [];
+    // prepare data in channel
+    for (let i = 0; i < numEntries; i++) {
+        channelEntries.push({
+            data: `Profile ${i} data`,
+            uuid: uuidv4(),
+        })
+        const res = await request(app)
+        .post(`/upload/${channelId}`)
+        .send(channelEntries[i])
+        .expect(201)
+    }
+    // double-check channel list returns correct size
+    const res = await request(app)
+    .get(`/list/${channelId}`)
+    .expect(200)
+    expect(res.body.profileIds).toHaveLength(numEntries);
+
+    return {channelId, channelEntries}
+}
+
+describe('Remove items from channel', () => {
+
+    let channelId
+    let channelEntries;
+    const numEntries = 3;
+
+    describe('Delete invalid entries', () => {
+        // Setup random channel
+        beforeAll(async ()=>{
+            const channelData = await setupChannel(numEntries)
+            channelId = channelData.channelId
+            channelEntries = channelData.channelEntries
+        })
+
+        it(`should handle deleting entries in non-existing channel`, async () => {
+            const invalidChannelId = uuidv4();
+            const deleteResult = await request(app)
+            .delete(`/${invalidChannelId}/${channelEntries[0].uuid}`)
+            .expect(404)
+        })
+
+        it(`should handle deleting non-existing entry`, async () => {
+            const invalidEntryId = uuidv4();
+            const deleteResult = await request(app)
+            .delete(`/${channelId}/${invalidEntryId}`)
+            .expect(404)
+        })
+    })
+
+    describe('Repeated deletion of same entry', () => {
+        // Setup random channel
+        beforeAll(async ()=>{
+            const channelData = await setupChannel(numEntries)
+            channelId = channelData.channelId
+            channelEntries = channelData.channelEntries
+        })
+
+        it(`should delete first entry`, async () => {
+            const deleteResult = await request(app)
+            .delete(`/${channelId}/${channelEntries[0].uuid}`)
+            .expect(200)
+
+            // number of entries in channel should be reduced
+            const res = await request(app)
+            .get(`/list/${channelId}`)
+            .expect(200)
+            expect(res.body.profileIds).toHaveLength(numEntries - 1);
+            // first entry should not exist anymore
+            expect(res.body.profileIds).not.toContain(channelEntries[0].uuid)
+            // other entries should still exist
+            for (let i=1; i < numEntries; i++) {
+                expect(res.body.profileIds).toContain(channelEntries[i].uuid)
+            }
+        })
+
+        it(`should delete the same entry again`, async () => {
+            const deleteResult = await request(app)
+            .delete(`/${channelId}/${channelEntries[0].uuid}`)
+            .expect(404)
+
+            // channel list should return correct size
+            const res = await request(app)
+            .get(`/list/${channelId}`)
+            .expect(200)
+            expect(res.body.profileIds).toHaveLength(numEntries - 1);
+            // first entry should not exist
+            expect(res.body.profileIds).not.toContain(channelEntries[0].uuid)
+            // other entries should still exist
+            for (let i=1; i < numEntries; i++) {
+                expect(res.body.profileIds).toContain(channelEntries[i].uuid)
+            }
+        })
+    })
+
+    describe('Delete all entries', () => {
+
+        // Setup random channel
+        beforeAll(async ()=>{
+            const channelData = await setupChannel(numEntries)
+            channelId = channelData.channelId
+            channelEntries = channelData.channelEntries
+        })
+
+        it('should delete all entries', async () => {
+            for (let i=0; i < numEntries; i++) {
+                const deleteResult = await request(app)
+                .delete(`/${channelId}/${channelEntries[i].uuid}`)
+                .expect(200)
+            }
+        })
+
+        it('Should return empty channel list', async () => {
+            const res = await request(app)
+            .get(`/list/${channelId}`)
+            .expect(200)
+            expect(res.body.profileIds).toHaveLength(0);
+        })
+    })
+
+    describe('Respect channel limits', () => {
+        // Setup random channel and fill it to the limit
+        beforeAll(async ()=>{
+            const channelData = await setupChannel(config.channel_entry_limit)
+            channelId = channelData.channelId
+            channelEntries = channelData.channelEntries
+        })
+
+        it('Should fail to exceed channel limit', async () => {
+            const additionalEntry = {
+                data: `extra entry`,
+                uuid: uuidv4(),
+            }
+            const res = await request(app)
+            .post(`/upload/${channelId}`)
+            .send(additionalEntry)
+            .expect(config.channel_limit_response_code)
+        })
+
+        it ('should succeed to add an entry after deleting one', async () => {
+            const additionalEntry = {
+                data: `extra entry`,
+                uuid: uuidv4(),
+            }
+            // first try should fail
+            await request(app)
+            .post(`/upload/${channelId}`)
+            .send(additionalEntry)
+            .expect(config.channel_limit_response_code)
+
+            // now delete one entry
+            await request(app)
+            .delete(`/${channelId}/${channelEntries[0].uuid}`)
+            .expect(200)
+
+            // now adding should succeed
+            const res = await request(app)
+            .post(`/upload/${channelId}`)
+            .send(additionalEntry)
+            .expect(201)
+        })
+    })
+})


### PR DESCRIPTION
This will allow the client to use channels as a queue/buffer: 
- the uploading client will pause adding entries when the service replies with "channel full"
- the downloading client will trigger a `delete` for each entry it processed, this way making space for additional uploads
- uploading client can retry/resume uploading entries after waiting some time 